### PR TITLE
add replication agreement checks for updatelaststart = epoch and upda…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 dist
 py27
 py36
+.venv


### PR DESCRIPTION
…telastend = epoch

Fixes # .

Changes proposed in this pull request:
  - Added .venv to gitignore to facilitate development
  - Added check for replication agreement failure corner case: In some circumstances the freeipa server can receive replica updates, but when it tries to send, it repeatedly fails with status 18. Since this is a backoff status we cannot automatically assume status 18 is a failure condition. However under these circumstances, nsds5replicaLastUpdateStart and/or nsds5replicaLastUpdateEnd associated with the replication agreement will be equal to EPOCH. While this also occurs just after restarting freeipa, it should not remain in this state for long. Adding this check validates you are not continuously in status 18.


@peterpakos
